### PR TITLE
improve closure, simplify code and make it without ng-min.

### DIFF
--- a/src/ui-router-history.js
+++ b/src/ui-router-history.js
@@ -1,70 +1,67 @@
-var _history_ = [];
+/* global angular */
 
-function $StateHistoryProvider () {
-	this.$get = $StateHistoryFactory;
-
-	function $StateHistoryFactory ($rootScope, $state, $q) {
-		var $stateHistory = {};
-
-		function setLastState (st) {
-			_history_.unshift(st);
-		}
-
-		function hasNextLastState () {
-			return angular.isObject(_nextLastState_);
-		}
-
-		function getLastState () {
-			return _history_[0];
-		}
-
-		var _isHistoryLocked_ = false;
-		function lockHistory () {
-			_isHistoryLocked_ = true;
-		}
-
-		function unlockHistory () {
-			_isHistoryLocked_ = false;
-		}
-
-		function isHistoryLocked () {
-			return _isHistoryLocked_;
-		}
-
-		$stateHistory.isHistoryLocked = isHistoryLocked;
-
-		$stateHistory.back = function () {
-			if(!isHistoryLocked()) {
-				lockHistory();
-			}
-
-			var lastState = $stateHistory.getLastState();
-			return $state.go(lastState.state.name, lastState.params).then(function () {
-				_history_.splice(_history_.indexOf(lastState), 1);
-				unlockHistory();
-			});
-		};
-
-		$stateHistory.getHistory = function () {
-			return _history_;
-		}
-
-		$stateHistory.clear = function () {
-			_history_ = [];
-		};
-
-		$stateHistory.lockHistory = lockHistory;
-		$stateHistory.unlockHistory = unlockHistory;
-		$stateHistory.getLastState = getLastState;
-		$stateHistory.setLastState = setLastState;
-
-		return $stateHistory;
-	}
-}
+(function () {
+'use strict';
 
 angular.module('ui-router-history', ['ui.router'])
-.provider('$stateHistory', $StateHistoryProvider)
-.run(function ($rootScope, $stateHistory) {
+.factory('$stateHistory', ['$rootScope', '$state', '$q', function ($rootScope, $state, $q) {
+	
+	var _history_ = [];
+	var _isHistoryLocked_ = false;
+	
+	function setLastState (st) {
+		_history_.unshift(st);
+	}
+
+	function hasNextLastState () {
+		return angular.isObject(_nextLastState_);
+	}
+
+	function getLastState () {
+		return _history_[0];
+	}
+
+	function lockHistory () {
+		_isHistoryLocked_ = true;
+	}
+
+	function unlockHistory () {
+		_isHistoryLocked_ = false;
+	}
+
+	function isHistoryLocked () {
+		return _isHistoryLocked_;
+	}
+
+	$stateHistory.back = function () {
+		if(!isHistoryLocked()) {
+			lockHistory();
+		}
+
+		var lastState = getLastState();
+		return $state.go(lastState.state.name, lastState.params).then(function () {
+			_history_.splice(_history_.indexOf(lastState), 1);
+			unlockHistory();
+		});
+	};
+
+	$stateHistory.getHistory = function () {
+		return _history_;
+	}
+
+	$stateHistory.clear = function () {
+		_history_ = [];
+	};
+	
+	return {
+		setLastState:    setLastState,
+		getLastState:    getLastState,
+		lockHistory:     lockHistory,
+		unlockHistory:   unlockHistory,
+		isHistoryLocked: isHistoryLocked
+	};
+})
+.run(['$rootScope', '$stateHistory', function ($rootScope, $stateHistory) {
 	$rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
 		if($stateHistory.isHistoryLocked()) {
 			return $stateHistory.unlockHistory();
@@ -75,4 +72,6 @@ angular.module('ui-router-history', ['ui.router'])
 			params: fromParams
 		});
 	});
-});
+}]);
+
+})();


### PR DESCRIPTION
nice lib. i propose some small changes:

* _history_ variable was poluting global scope. I encapsulated the module so it only exposes the actual angular module.
* the provider approach was making the code harder to read and, as there was no config option, there was no necessity of the added complexity.
* functions were calling dependencies directly as parameters, not using the array approach. that would not work if the code was minified and someone was not using the ng-min library. that would still not work in some places because the ng-min can not minify parameters passed on ordinary functions (as it was being used inside the provider approach).